### PR TITLE
build: Support for IntelliJ 2025.3

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## Overview
+
+## Issue number
+
+## Changes

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ pluginRepositoryUrl = https://github.com/naoyukik/customize-word-separators-kt
 pluginVersion = 0.6.6
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 243
-pluginUntilBuild=252.*
+pluginSinceBuild=244
+pluginUntilBuild=253.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU


### PR DESCRIPTION
## チケット
#138

## 概要
IntelliJ Platformのビルド範囲を更新し、2025.3をサポートする。

## 変更点
- `build.gradle.kts` の `untilBuild` を `253.*` に更新