### PR TITLE
build: bump plugin version to 0.6.7 and support IntelliJ 2025.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Support for IntelliJ 2025.3
+
 ## [0.6.6] - 2025-05-17
 
 ### refactor

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = net.dstribe.customize_word_separators
 pluginName = Customize Word Separators
 pluginRepositoryUrl = https://github.com/naoyukik/customize-word-separators-kt
 # SemVer format -> https://semver.org
-pluginVersion = 0.6.6
+pluginVersion=0.6.7
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=244


### PR DESCRIPTION
## Overview
This pull request updates the plugin version to 0.6.7 and extends support for IntelliJ 2025.3.

## Issue number
#138

## Changes
- Bump plugin version to 0.6.7
- Add support for IntelliJ IDEA 2025.3
- Update IntelliJ platform version compatibility range